### PR TITLE
Adjust tests to SQLite 3.22.0 which outputs a different error message.

### DIFF
--- a/t/53_driver_dbi_bad.t
+++ b/t/53_driver_dbi_bad.t
@@ -98,9 +98,9 @@ my %options = (
         [ 'user1', '123' ],
         [ 'user2', '123' ],
     );}
-   qr/Error executing class callback in prerun stage: Failed to prepare SQL statement:  near " "/,
+   qr/Error executing class callback in prerun stage: Failed to prepare SQL statement:  (near " "|incomplete input)/,
    "DBI syntax error";}
-   qr/DBD::SQLite::db prepare_cached failed: near " ": syntax error/, "DBD:SQLite";
+   qr/DBD::SQLite::db prepare_cached failed: (near " ": syntax error|incomplete input)/, "DBD:SQLite";
 }
 
 {


### PR DESCRIPTION

In Debian we are currently applying the following patch to
CGI-Application-Plugin-Authentication.
We thought you might be interested in it too.

    Description: Adjust tests to SQLite 3.22.0 which outputs a different error message.
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-01-31
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libcgi-application-plugin-authentication-perl.git/plain/debian/patches/sqlite3-3.22.0.patch


PS: This won't show up on CPAN testers until DBD::SQLite embeds the newer
SQLite (in Debian we're building it against the system library).

Log for build failure at
https://ci.debian.net/packages/libc/libcgi-application-plugin-authentication-perl/unstable/amd64/


Thanks for considering,
  gregor herrmann,
  Debian Perl Group
